### PR TITLE
Add `linkedin.com` domain suffix to general global services

### DIFF
--- a/List/non_ip/domestic.conf
+++ b/List/non_ip/domestic.conf
@@ -299,7 +299,7 @@ DOMAIN-SUFFIX,kaspersky-labs.com
 DOMAIN-SUFFIX,keepcdn.com
 DOMAIN-SUFFIX,kkmh.com
 DOMAIN-SUFFIX,licdn.com
-DOMAIN-SUFFIX,linkedin.com
+DOMAIN-SUFFIX,linkedin.cn
 DOMAIN-SUFFIX,luojilab.com
 DOMAIN-SUFFIX,maoyan.com
 DOMAIN-SUFFIX,maoyun.tv

--- a/List/non_ip/global.conf
+++ b/List/non_ip/global.conf
@@ -65,6 +65,7 @@ DOMAIN-SUFFIX,g.co
 # >> Microsoft Overseas
 DOMAIN-SUFFIX,office365.com
 DOMAIN-SUFFIX,windows.net
+DOMAIN-SUFFIX,linkedin.com
 
 # >> Oracle
 DOMAIN-SUFFIX,oracle.com


### PR DESCRIPTION
## 动机

[考虑到很多人并不希望](https://www.google.com/search?q=linkedin+%E9%87%8D%E5%AE%9A%E5%90%91+cn&sxsrf=ALiCzsYjLhb7sRhJqd4r0ulGAmJcsIum4w%3A1672759325506&ei=HUi0Y7C8HoSN-AahqIaIDQ&ved=0ahUKEwjwvpCL2qv8AhWEBt4KHSGUAdEQ4dUDCA8&oq=linkedin+%E9%87%8D%E5%AE%9A%E5%90%91+cn&gs_lcp=Cgxnd3Mtd2l6LXNlcnAQDEoECEEYAEoECEYYAFAAWABgAGgAcAF4AIABAIgBAJIBAJgBAA&sclient=gws-wiz-serp)访问 `linkedin.com` 时因为走直连而被重定向至 `linkedin.cn`，对配置文件做了一些改动

## 修改

1. 将 `DOMAIN-SUFFIX,linkedin.cn` 添加到 *List/non_ip/domestic.conf*，尽可能地不影响 `linkedin.cn` 用户的直连访问
2. 将 `DOMAIN-SUFFIX,linkedin.com` 添加到 *List/non_ip/global.conf*，尽可能地满足大部分人不希望访问 `linkedin.com` 时被重定向至 .cn 的需求