### PR TITLE
fix reject_drop.conf url

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ```ini
 # Non IP
-RULE-SET,https://ruleset.skk.moe/List/ip/reject-drop.conf,REJECT-DROP
+RULE-SET,https://ruleset.skk.moe/List/non_ip/reject-drop.conf,REJECT-DROP
 DOMAIN-SET,https://ruleset.skk.moe/List/domainset/reject.conf,REJECT-TINYGIF
 RULE-SET,https://ruleset.skk.moe/List/non_ip/reject.conf,REJECT
 # IP


### PR DESCRIPTION
顺便提一下：
```
https://ruleset.skk.moe/List/domainset/download.conf
https://ruleset.skk.moe/List/ip/download.conf
https://ruleset.skk.moe/List/non_ip/apple_services.conf
```
这3个文件可以在浏览器中打开，但是在Surge资源更新中一直提示：Failed to parse remote resource data