### PR TITLE
add github copilot; add chatgpt.com for openai

### DIFF
--- a/Source/non_ip/ai.conf
+++ b/Source/non_ip/ai.conf
@@ -7,6 +7,7 @@ DOMAIN-KEYWORD,openai
 # DOMAIN-SUFFIX,openai.com
 DOMAIN-SUFFIX,oaistatic.com
 DOMAIN-SUFFIX,oaiusercontent.com
+DOMAIN-SUFFIX,chatgpt.com
 DOMAIN-SUFFIX,ai.com
 DOMAIN-SUFFIX,x.ai
 # DOMAIN-SUFFIX,openaiapi-site.azureedge.net
@@ -32,3 +33,6 @@ DOMAIN,alkalimakersuite-pa.clients6.google.com
 DOMAIN-SUFFIX,generativeai.google
 # POE
 DOMAIN-SUFFIX,poe.com
+# github copilot
+DOMAIN,copilot-proxy.githubusercontent.com
+DOMAIN,copilot-telemetry.githubusercontent.com

--- a/Source/non_ip/ai.conf
+++ b/Source/non_ip/ai.conf
@@ -33,6 +33,3 @@ DOMAIN,alkalimakersuite-pa.clients6.google.com
 DOMAIN-SUFFIX,generativeai.google
 # POE
 DOMAIN-SUFFIX,poe.com
-# github copilot
-DOMAIN,copilot-proxy.githubusercontent.com
-DOMAIN,copilot-telemetry.githubusercontent.com


### PR DESCRIPTION
<img width="793" alt="image" src="https://github.com/SukkaW/Surge/assets/18593673/01bdd34c-37e7-4c5c-9fe7-dd99c81c8e3f">

surge dashboard提示ab.chatgpt.com仍然是直连,所以加上了.

顺便添加了github copilot的规则