### PR TITLE
Update `global.conf` and `direct.conf`

### DIFF
--- a/Source/non_ip/direct.conf
+++ b/Source/non_ip/direct.conf
@@ -60,12 +60,12 @@ PROCESS-NAME,Logi Options
 PROCESS-NAME,Logi Options Daemon
 
 # >> PT
+DOMAIN-KEYWORD,tracker
 DOMAIN-SUFFIX,52pt.site
 DOMAIN-SUFFIX,acg.rip
 DOMAIN-SUFFIX,animebytes.tv
 DOMAIN-SUFFIX,aidoru-online.me
 DOMAIN-SUFFIX,alpharatio.cc
-DOMAIN-SUFFIX,animebytes.tv
 DOMAIN-SUFFIX,anthelion.me
 DOMAIN-SUFFIX,asiancinema.me
 DOMAIN-SUFFIX,avgv.cc
@@ -128,7 +128,6 @@ DOMAIN-SUFFIX,karagarga.in
 DOMAIN-SUFFIX,keepfrds.com
 DOMAIN-SUFFIX,leaguehd.com
 DOMAIN-SUFFIX,lztr.me
-DOMAIN-SUFFIX,m-team.cc
 DOMAIN-SUFFIX,madsrevolution.net
 DOMAIN-SUFFIX,moecat.best
 DOMAIN-SUFFIX,morethan.tv
@@ -142,7 +141,6 @@ DOMAIN-SUFFIX,npupt.com
 DOMAIN-SUFFIX,open.cd
 DOMAIN-SUFFIX,oppaiti.me
 DOMAIN-SUFFIX,orpheus.network
-DOMAIN-SUFFIX,ourbits.club
 DOMAIN-SUFFIX,passthepopcorn.me
 DOMAIN-SUFFIX,pornbits.net
 DOMAIN-SUFFIX,privatehd.to
@@ -157,7 +155,6 @@ DOMAIN-SUFFIX,springsunday.net
 DOMAIN-SUFFIX,tjupt.org
 DOMAIN-SUFFIX,totheglory.im
 DOMAIN-SUFFIX,trontv.com
-DOMAIN-SUFFIX,u2.dmhy.org
 DOMAIN-SUFFIX,uhdbits.org
 
 # >> Academic

--- a/Source/non_ip/global.conf
+++ b/Source/non_ip/global.conf
@@ -1,6 +1,12 @@
 # $ meta_title Sukka's Ruleset - General Global Services
 # $ meta_description This file contains rules for services that are not available inside the Mainland China.
 
+# >> PT
+DOMAIN-SUFFIX,m-team.cc
+DOMAIN-SUFFIX,m-team.io
+DOMAIN-SUFFIX,ourbits.club
+DOMAIN-SUFFIX,u2.dmhy.org
+
 # >> Google
 DOMAIN-SUFFIX,abc.xyz
 DOMAIN-SUFFIX,ampproject.org


### PR DESCRIPTION
删除 `direct.conf` 中的重复行
添加了一条 `DOMAIN-KEYWORD` 规则以过滤大部分 tracker 域名
移动部分站点至 `global.conf` 以解决部分地区运营商的屏蔽问题