### PR TITLE
Add cdn.winget.microsoft.com

### DIFF
--- a/Source/non_ip/global.conf
+++ b/Source/non_ip/global.conf
@@ -403,6 +403,7 @@ DOMAIN-SUFFIX,cachefly.net
 DOMAIN-SUFFIX,castbox.fm
 DOMAIN-SUFFIX,cbc.ca
 DOMAIN,ccmdl.adobe.com
+DOMAIN-SUFFIX,cdn.winget.microsoft.com
 DOMAIN-SUFFIX,cdpn.io
 DOMAIN-SUFFIX,change.org
 DOMAIN-SUFFIX,character.ai


### PR DESCRIPTION
cdn.winget.microsoft.com is used by `winget.exe` to detect software updates but is suspected to be blocked and cannot be connected directly.