### PR TITLE
Feat: implement HTTP 304 with SQLite Cache

### DIFF
--- a/Build/build-apple-cdn.ts
+++ b/Build/build-apple-cdn.ts
@@ -2,15 +2,13 @@ import { parseFelixDnsmasqFromResp } from './lib/parse-dnsmasq';
 import { task } from './trace';
 import { SHARED_DESCRIPTION } from './lib/constants';
 import { createMemoizedPromise } from './lib/memo-promise';
-import { deserializeArray, fsFetchCache, serializeArray, createCacheKey } from './lib/cache-filesystem';
+import { deserializeArray, fsFetchCache, serializeArray, getFileContentHash } from './lib/cache-filesystem';
 import { DomainsetOutput } from './lib/create-file';
-
-const cacheKey = createCacheKey(__filename);
 
 const url = 'https://raw.githubusercontent.com/felixonmars/dnsmasq-china-list/master/apple.china.conf';
 export const getAppleCdnDomainsPromise = createMemoizedPromise(() => fsFetchCache.applyWithHttp304(
   url,
-  cacheKey(url),
+  getFileContentHash(__filename),
   parseFelixDnsmasqFromResp,
   {
     serializer: serializeArray,

--- a/Build/build-apple-cdn.ts
+++ b/Build/build-apple-cdn.ts
@@ -1,18 +1,18 @@
-import { parseFelixDnsmasq } from './lib/parse-dnsmasq';
+import { parseFelixDnsmasqFromResp } from './lib/parse-dnsmasq';
 import { task } from './trace';
 import { SHARED_DESCRIPTION } from './lib/constants';
 import { createMemoizedPromise } from './lib/memo-promise';
-import { TTL, deserializeArray, fsFetchCache, serializeArray, createCacheKey } from './lib/cache-filesystem';
+import { deserializeArray, fsFetchCache, serializeArray, createCacheKey } from './lib/cache-filesystem';
 import { DomainsetOutput } from './lib/create-file';
 
 const cacheKey = createCacheKey(__filename);
 
 const url = 'https://raw.githubusercontent.com/felixonmars/dnsmasq-china-list/master/apple.china.conf';
-export const getAppleCdnDomainsPromise = createMemoizedPromise(() => fsFetchCache.apply(
+export const getAppleCdnDomainsPromise = createMemoizedPromise(() => fsFetchCache.applyWithHttp304(
+  url,
   cacheKey(url),
-  () => parseFelixDnsmasq(url),
+  parseFelixDnsmasqFromResp,
   {
-    ttl: TTL.THREE_DAYS(),
     serializer: serializeArray,
     deserializer: deserializeArray
   }

--- a/Build/lib/download-publicsuffixlist.ts
+++ b/Build/lib/download-publicsuffixlist.ts
@@ -1,18 +1,14 @@
-import { TTL, deserializeArray, fsFetchCache, serializeArray, createCacheKey } from './cache-filesystem';
-import { defaultRequestInit, fetchWithRetry } from './fetch-retry';
+import { deserializeArray, fsFetchCache, getFileContentHash, serializeArray } from './cache-filesystem';
 import { createMemoizedPromise } from './memo-promise';
 
-const cacheKey = createCacheKey(__filename);
-
-export const getPublicSuffixListTextPromise = createMemoizedPromise(() => fsFetchCache.apply(
-  cacheKey('https://publicsuffix.org/list/public_suffix_list.dat'),
-  () => fetchWithRetry('https://publicsuffix.org/list/public_suffix_list.dat', defaultRequestInit)
-    .then(r => r.text()).then(text => text.split('\n')),
+export const getPublicSuffixListTextPromise = createMemoizedPromise(() => fsFetchCache.applyWithHttp304<string[]>(
+  'https://publicsuffix.org/list/public_suffix_list.dat',
+  getFileContentHash(__filename),
+  (r) => r.text().then(text => text.split('\n')),
   {
     // https://github.com/publicsuffix/list/blob/master/.github/workflows/tld-update.yml
     // Though the action runs every 24 hours, the IANA list is updated every 7 days.
     // So a 3 day TTL should be enough.
-    ttl: TTL.THREE_DAYS(),
     serializer: serializeArray,
     deserializer: deserializeArray
   }

--- a/Build/lib/fetch-retry.ts
+++ b/Build/lib/fetch-retry.ts
@@ -89,7 +89,7 @@ function createFetchRetry($fetch: typeof fetch): FetchWithRetry {
             }
             throw new ResponseError(res);
           } else {
-            if (!res.ok && retryOpts.retryOnNon2xx) {
+            if ((!res.ok && res.status !== 304) && retryOpts.retryOnNon2xx) {
               throw new ResponseError(res);
             }
             return res;
@@ -106,7 +106,7 @@ function createFetchRetry($fetch: typeof fetch): FetchWithRetry {
             return bail(err) as never;
           }
 
-          console.log(picocolors.gray('[fetch fail]'), url);
+          console.log(picocolors.gray('[fetch fail]'), url, err);
           throw err;
         }
       }, retryOpts);

--- a/Build/lib/misc.ts
+++ b/Build/lib/misc.ts
@@ -95,3 +95,30 @@ export function withBannerArray(title: string, description: string[] | readonly 
     '################## EOF ##################'
   ];
 };
+
+export const mergeHeaders = (headersA: RequestInit['headers'] | undefined, headersB: RequestInit['headers']) => {
+  if (headersA == null) {
+    return headersB;
+  }
+
+  if (Array.isArray(headersB)) {
+    throw new TypeError('Array headers is not supported');
+  }
+
+  const result = new Headers(headersA);
+
+  if (headersB instanceof Headers) {
+    headersB.forEach((value, key) => {
+      result.set(key, value);
+    });
+    return result;
+  }
+
+  for (const key in headersB) {
+    if (Object.hasOwn(headersB, key)) {
+      result.set(key, (headersB as Record<string, string>)[key]);
+    }
+  }
+
+  return result;
+};

--- a/Build/lib/parse-filter.ts
+++ b/Build/lib/parse-filter.ts
@@ -159,11 +159,7 @@ export async function processFilterRules(
   ttl: number | null = null,
   allowThirdParty = false
 ): Promise<{ white: string[], black: string[], foundDebugDomain: boolean }> {
-  const [white, black, warningMessages] = await parentSpan.traceChild(`process filter rules: ${filterRulesUrl}`).traceAsyncFn((span) => fsFetchCache.apply<Readonly<[
-    white: string[],
-    black: string[],
-    warningMessages: string[]
-  ]>>(
+  const [white, black, warningMessages] = await parentSpan.traceChild(`process filter rules: ${filterRulesUrl}`).traceAsyncFn((span) => fsFetchCache.apply<Readonly<[ white: string[], black: string[], warningMessages: string[] ]>>(
     cacheKey(filterRulesUrl),
     async () => {
       const whitelistDomainSets = new Set<string>();


### PR DESCRIPTION
Previously we used specified random TTL to prevent excessive HTTP requests. However, this approach might result in stale content.

The PR instead tries to adopt HTTP 304. It introduces a new method, `applyWithHttp304,` which will also store the ETag response header in SQLite.

TODO: Currently the implementation lacks the support for fetching mirror URLs in parallel. We might also wanna store 304 in a separate table to prevent clogging up the main cache table.