### PR TITLE
add Github Copilot (Claude)

### DIFF
--- a/Source/non_ip/ai.conf
+++ b/Source/non_ip/ai.conf
@@ -54,5 +54,4 @@ DOMAIN-SUFFIX,jasper.ai
 # OpenArt
 DOMAIN-SUFFIX,openart.ai
 # GitHub Copilot
-DOMAIN-SUFFIX,githubcopilot.com
 DOMAIN,api.github.com

--- a/Source/non_ip/ai.conf
+++ b/Source/non_ip/ai.conf
@@ -55,8 +55,4 @@ DOMAIN-SUFFIX,jasper.ai
 DOMAIN-SUFFIX,openart.ai
 # GitHub Copilot
 DOMAIN-SUFFIX,githubcopilot.com
-DOMAIN,copilot-proxy.githubusercontent.com
-# Github Copilot (Claude)
-DOMAIN,copilot-telemetry.githubusercontent.com
-DOMAIN-SUFFIX,exp-tas.com
-DOMAIN,origin-tracker.githubusercontent.com
+DOMAIN,api.github.com

--- a/Source/non_ip/ai.conf
+++ b/Source/non_ip/ai.conf
@@ -53,3 +53,10 @@ DOMAIN-SUFFIX,clipdrop.co
 DOMAIN-SUFFIX,jasper.ai
 # OpenArt
 DOMAIN-SUFFIX,openart.ai
+# GitHub Copilot
+DOMAIN-SUFFIX,githubcopilot.com
+DOMAIN,copilot-proxy.githubusercontent.com
+# Github Copilot (Claude)
+DOMAIN,copilot-telemetry.githubusercontent.com
+DOMAIN-SUFFIX,exp-tas.com
+DOMAIN,origin-tracker.githubusercontent.com


### PR DESCRIPTION
Github Copilot started offering Claude 3.5 Sonnet using the AWS Bedroc, but began restricting Copilot access regions, possibly due to partnership restrictions.

[references](https://docs.github.com/en/copilot/using-github-copilot/using-claude-sonnet-in-github-copilot)