### PR TITLE
Add groq domain to `ai.conf`

### DIFF
--- a/Source/non_ip/ai.conf
+++ b/Source/non_ip/ai.conf
@@ -53,3 +53,5 @@ DOMAIN-SUFFIX,clipdrop.co
 DOMAIN-SUFFIX,jasper.ai
 # OpenArt
 DOMAIN-SUFFIX,openart.ai
+# groq
+DOMAIN-SUFFIX,groq.com


### PR DESCRIPTION
Add groq domain to `ai.conf`,
It's the [reference](https://groq.com/terms-of-use/) about the groq ToU.
Although the documentation not clearly stands out the limit of country, but it doesn't work in China mainland and Hongkong after my test.
So I recommend to add relevant domains to the ruleset.

> The rulesets in the project work very well in daily work, hope this project getting better.