### PR TITLE
fix: GitHub Reverse Proxy

### DIFF
--- a/Source/domainset/download.conf
+++ b/Source/domainset/download.conf
@@ -360,6 +360,7 @@ desktop.wifiman.com
 artifacts.electronjs.org
 # GitHub Reverse Proxy
 mirror.ghproxy.com
+ghp.ci
 # HashiCorp
 .releases.hashicorp.com
 # Homebrew


### PR DESCRIPTION
ghproxy.com now migrated to ghp.ci