### PR TITLE
Remove .internal.dradis.netflix.com

### DIFF
--- a/Source/domainset/reject_sukka.conf
+++ b/Source/domainset/reject_sukka.conf
@@ -962,7 +962,8 @@ bitanalytics.casperverswijvelt.be
 
 # CNAME: dualstack.beaconserver-ce-vpc0-1537565064.eu-west-1.elb.amazonaws.com
 # note "beaconserver"
-.internal.dradis.netflix.com
+# causing problems of netflix services
+# .internal.dradis.netflix.com
 
 .adjust.io
 .airbrake.io


### PR DESCRIPTION
This PR is to remove `.internal.dradis.netflix.com`

Blocking this domain will cause CNAME ban of innocent websites, like the `api.fast.com`, making it speedtest on <fast.com> unavailable. 

It also block my roommate from watching netflix.

``` shell
~# dig api.fast.com @1.1.1.1

; <<>> DiG 9.18.28-0ubuntu0.24.04.1-Ubuntu <<>> api.fast.com @1.1.1.1
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 4714
;; flags: qr rd ra; QUERY: 1, ANSWER: 6, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;api.fast.com.                  IN      A

;; ANSWER SECTION:
api.fast.com.           3461    IN      CNAME   fast.dradis.netflix.com.
fast.dradis.netflix.com. 60     IN      CNAME   fast.us-west-2.internal.dradis.netflix.com.
fast.us-west-2.internal.dradis.netflix.com. 60 IN CNAME apiproxy-api-fast-vpc0-nlb-103017a815808492.elb.us-west-2.amazonaws.com.
apiproxy-api-fast-vpc0-nlb-103017a815808492.elb.us-west-2.amazonaws.com. 60 IN A 35.161.104.116
apiproxy-api-fast-vpc0-nlb-103017a815808492.elb.us-west-2.amazonaws.com. 60 IN A 54.69.47.224
apiproxy-api-fast-vpc0-nlb-103017a815808492.elb.us-west-2.amazonaws.com. 60 IN A 44.236.74.109

;; Query time: 57 msec
;; SERVER: 1.1.1.1#53(1.1.1.1) (UDP)
;; WHEN: Fri Dec 13 08:09:08 UTC 2024
;; MSG SIZE  rcvd: 243
```

The test above was tested on a vps in the San Jose.

Similar response can be found in the test of my router in east america:

``` sh
root@ImmortalWrt:~# nslookup api.fast.com 1.1.1.1
Server:         1.1.1.1
Address:        1.1.1.1#53

Name:      api.fast.com
api.fast.com    canonical name = fast.dradis.netflix.com
Name:      fast.dradis.netflix.com
fast.dradis.netflix.com canonical name = fast.us-east-2.internal.dradis.netflix.com
Name:      fast.us-east-2.internal.dradis.netflix.com
fast.us-east-2.internal.dradis.netflix.com      canonical name = apiproxy-api-fast-vpc0-nlb-41a65773b29b9841.elb.us-east-2.amazonaws.com
Name:      apiproxy-api-fast-vpc0-nlb-41a65773b29b9841.elb.us-east-2.amazonaws.com
Address 1: 52.14.4.243
Address 2: 3.132.9.183
Address 3: 18.118.127.196
api.fast.com    canonical name = fast.dradis.netflix.com
fast.dradis.netflix.com canonical name = fast.us-east-2.internal.dradis.netflix.com
fast.us-east-2.internal.dradis.netflix.com      canonical name = apiproxy-api-fast-vpc0-nlb-41a65773b29b9841.elb.us-east-2.amazonaws.com
Address 4: 2a03:5640:f502:80::5452:cfbc
Address 5: 2a03:5640:f502:81::5452:cfbc
Address 6: 2a03:5640:f502:82::5452:cfbc
```

I didn't find any "beaconserver" logged when I watch netflix, and I can't find any similarr blocks from other repos, so I just removed it.