### PR TITLE
Update ai.conf

### DIFF
--- a/Source/non_ip/ai.conf
+++ b/Source/non_ip/ai.conf
@@ -43,6 +43,7 @@ DOMAIN-SUFFIX,aistudio.google.com
 DOMAIN-SUFFIX,makersuite.google.com
 DOMAIN,alkalicore-pa.clients6.google.com
 DOMAIN,alkalimakersuite-pa.clients6.google.com
+DOMAIN-SUFFIX,webchannel-alkalimakersuite-pa.clients6.google.com
 DOMAIN-SUFFIX,generativeai.google
 
 # >> Google NotebookLM


### PR DESCRIPTION
Google AI Studio中Stream Realtime几个功能均走的这个域名，目前的规则会导致该域名被分流至Google规则，导致Connection Failed.