### PR TITLE
Perfect claude domain to `ai.conf`

### DIFF
--- a/Source/non_ip/ai.conf
+++ b/Source/non_ip/ai.conf
@@ -23,6 +23,7 @@ DOMAIN-SUFFIX,perplexity.ai
 # >> Claude
 DOMAIN-SUFFIX,anthropic.com
 DOMAIN-SUFFIX,claude.ai
+DOMAIN-SUFFIX,claudeusercontent.com
 
 # >> Google Gemini
 DOMAIN-SUFFIX,bard.google.com


### PR DESCRIPTION
增加了claudeusercontent.com域名，访问claude.ai登陆时会访问该域名，如果和claude.ai落地不一致会被禁止登陆