### PR TITLE
Update Download Hosts: GitHub Reverse Proxy

### DIFF
--- a/Source/domainset/download.conf
+++ b/Source/domainset/download.conf
@@ -375,6 +375,8 @@ desktop.wifiman.com
 # Electron Artifacts
 artifacts.electronjs.org
 # GitHub Reverse Proxy
+ghfast.top
+ghgo.xyz
 mirror.ghproxy.com
 ghp.ci
 # HashiCorp


### PR DESCRIPTION
ghproxy.com and ghp.ci are now both unavailable, and two new domains have been added for the project.