### PR TITLE
Update direct.ts

### DIFF
--- a/Build/lib/create-file.worker.ts
+++ b/Build/lib/create-file.worker.ts
@@ -49,7 +49,7 @@ const pool = new Worktank({
 });
 
 export function compareAndWriteFileInWorker(span: Span, linesA: string[], filePath: string) {
-  return span.traceChildAsync(`compare and write ${filePath}`, () => pool.exec('compareAndWriteFile', [linesA, filePath, import.meta.url]));
+  return span.traceChildAsync(`compare and write (worker) ${filePath}`, () => pool.exec('compareAndWriteFile', [linesA, filePath, import.meta.url]));
 }
 
 process.on('beforeExit', () => pool.terminate());

--- a/Build/lib/writing-strategy/base.ts
+++ b/Build/lib/writing-strategy/base.ts
@@ -79,7 +79,7 @@ export abstract class BaseWriteStrategy {
       return;
     }
 
-    if (this.result.length > 1000) {
+    if (this.result.length > 2000) {
       return compareAndWriteFileInWorker(
         span,
         this.withPadding(

--- a/Source/non_ip/direct.ts
+++ b/Source/non_ip/direct.ts
@@ -144,6 +144,7 @@ export const LAN = {
     domains: [
       '+lan',
       '+local',
+      '+internal',
       // 'amplifi.lan',
       // '$localhost',
       '+localdomain',


### PR DESCRIPTION
The Internet Assigned Numbers Authority (IANA) has made a provisional determination that “.INTERNAL” should be reserved for private-use and internal network applications.

- [proposed-top-level-domain-string-for-private-use-24-01-2024](https://www.icann.org/en/public-comment/proceeding/proposed-top-level-domain-string-for-private-use-24-01-2024)