### PR TITLE
Add rule for grok.com

### DIFF
--- a/Source/non_ip/ai.conf
+++ b/Source/non_ip/ai.conf
@@ -76,5 +76,8 @@ DOMAIN-SUFFIX,openart.ai
 # see https://github.com/SukkaW/Surge/pull/46#discussion_r1849641627
 DOMAIN,api.github.com
 
+# >> Grok
+DOMAIN-SUFFIX,grok.com
+
 # >> groq
 DOMAIN-SUFFIX,groq.com


### PR DESCRIPTION
在 `Source/non_ip/ai.conf` 中添加了一条新规则 `DOMAIN-SUFFIX,grok.com`。