### PR TITLE
Comment out gTLD .wiki

### DIFF
--- a/Source/non_ip/global.conf
+++ b/Source/non_ip/global.conf
@@ -571,7 +571,7 @@ DOMAIN-SUFFIX,rip
 DOMAIN-SUFFIX,social
 DOMAIN-SUFFIX,tools
 DOMAIN-SUFFIX,watch
-DOMAIN-SUFFIX,wiki
+# DOMAIN-SUFFIX,wiki # fgo.wiki, prts.wiki
 DOMAIN-SUFFIX,xxx
 
 # >> ---------


### PR DESCRIPTION
gTLD .wiki 在中国大陆境内是可备案域名且有相对知名，位于中国大陆境内的 wiki 站（fgo.wiki, prts.wiki）使用了这个 TLD。因此该后缀不应当保留在 global.conf 中。