### PR TITLE
Delete appleintelligencefeedback.care.apple.com

### DIFF
--- a/Source/non_ip/apple_cn.conf
+++ b/Source/non_ip/apple_cn.conf
@@ -9,4 +9,3 @@ DOMAIN-SUFFIX,cn-ssl.ls.apple.com
 DOMAIN,gs-loc-cn.apple.com
 DOMAIN-SUFFIX,icloud.com.cn
 DOMAIN-SUFFIX,gspe19-cn-ssl.ls.apple.com
-DOMAIN,appleintelligencefeedback.care.apple.com


### PR DESCRIPTION
Unfortunately, this website existed for only a few hours. 

Currently, it displays the message “The page you're looking for can't be found,” with a 403 status code.

Some Sources indicate it may have been migrated to a new domain. But I couldn't find it. Maybe it is not exist. As things stand, i think no special action is required to this domain, just delete it.