### PR TITLE
Remove .substack.com from reject.conf

### DIFF
--- a/Source/domainset/reject.conf
+++ b/Source/domainset/reject.conf
@@ -426,7 +426,6 @@ inst.360safe.com
 # Notorious Bulk Phishing/Spam Email Sender
 .sephora.com
 .tiscali.it
-.substack.com
 .smallstep.org
 .gop.com
 


### PR DESCRIPTION
Substack is a subscription platform like onlyfans/wordpress, shouldn't be rejected.