### PR TITLE
Whitelist `cloudflarestorage.com` from Phishing Apex Aggregation

### DIFF
--- a/Build/constants/phishing-score-source.ts
+++ b/Build/constants/phishing-score-source.ts
@@ -46,6 +46,7 @@ export const WHITELIST_MAIN_DOMAINS = new Set([
   'myqcloud.com', // curben phishing-filter contains many entries
   'surge.sh', // caused by phishing-filter, also no public suffix
   'backblazeb2.com', // phishing-filter, no publicsuffix, too much abuse
+  'cloudflarestorage.com', // Cloudflare R2 S3-API endpoint, phishing-filter false-positives the entire apex
 
   'pages.dev',
   'workers.dev'


### PR DESCRIPTION
## Background

With `reject_phishing.conf` active, legitimate Cloudflare R2 downloads hosted at `<account-id>.r2.cloudflarestorage.com`, including application update packages, are blocked by the generated `.cloudflarestorage.com` rule.

## Root cause

Cloudflare R2 uses `cloudflarestorage.com` as its shared S3 API endpoint. `get-phishing-domains.ts` aggregates phishing-feed entries by registrable apex, scores them, and emits a blanket `.<apex>` reject when the thresholds are crossed. Because `cloudflarestorage.com` is not in `WHITELIST_MAIN_DOMAINS`, reports for abusive R2 buckets cause the entire apex to be rejected.

R2 is genuinely abused for phishing, but the whitelist already exempts comparable shared object-storage apexes such as `backblazeb2.com`, `myqcloud.com`, and `windows.net`. `download.conf` also lists `.cloudflarestorage.com` as a legitimate object-storage host, which conflicts with rejecting the entire apex.

## Solution

Add `cloudflarestorage.com` to `WHITELIST_MAIN_DOMAINS`, adjacent to `backblazeb2.com` and `myqcloud.com`.

This removes only the blanket apex reject. Specific malicious hosts from the curated `PHISHING_HOSTS_EXTRA` lists continue to be emitted and blocked.
