### PR TITLE
Update CDN Hosts

### DIFF
--- a/Source/domainset/cdn.conf
+++ b/Source/domainset/cdn.conf
@@ -457,6 +457,8 @@ optimizationguide-pa.googleapis.com
 # >> Apple CDN
 static.ess.apple.com
 sequoia.cdn-apple.com
+# Apple Fitness+
+hls-svod.itunes.apple.com
 # Apple Live
 events-live.apple.com
 events-delivery.apple.com


### PR DESCRIPTION
In Apple Fitness+, `hls-svod.itunes.apple.com` is used to load video streams.