### PR TITLE
Whitelist `chat.z.ai` phishing false positive

### DIFF
--- a/Build/constants/phishing-score-source.ts
+++ b/Build/constants/phishing-score-source.ts
@@ -49,7 +49,8 @@ export const WHITELIST_MAIN_DOMAINS = new Set([
   'cloudflarestorage.com', // Cloudflare R2 S3-API endpoint, phishing-filter false-positives the entire apex
 
   'pages.dev',
-  'workers.dev'
+  'workers.dev',
+  'chat.z.ai' // Zhipu AI (Z.ai) GLM chat interface, legitimate service, false positive from phishing scoring
 ]);
 
 export const leathalKeywords = createKeywordFilter([


### PR DESCRIPTION
chat.z.ai is the GLM chat interface of Z.ai (Zhipu AI), a legitimate AI service. The phishing scoring algorithm collaterally blocklisted the apex. Add it to WHITELIST_MAIN_DOMAINS alongside other legit hosts (pages.dev, surge.sh, etc.).