### PR TITLE
Add chatgpt.site to AI ruleset

### DIFF
--- a/Source/non_ip/ai.conf
+++ b/Source/non_ip/ai.conf
@@ -8,6 +8,7 @@ DOMAIN-SUFFIX,openai.com
 DOMAIN-SUFFIX,oaistatic.com
 DOMAIN-SUFFIX,sora.com
 DOMAIN-SUFFIX,chatgpt.com
+DOMAIN-SUFFIX,chatgpt.site
 DOMAIN-SUFFIX,chat.com
 DOMAIN-SUFFIX,ai.com
 DOMAIN-KEYWORD,openai

--- a/Source/non_ip/ai.conf
+++ b/Source/non_ip/ai.conf
@@ -8,6 +8,7 @@ DOMAIN-SUFFIX,openai.com
 DOMAIN-SUFFIX,oaistatic.com
 DOMAIN-SUFFIX,sora.com
 DOMAIN-SUFFIX,chatgpt.com
+# Confirmed by https://github.com/SukkaW/Surge/pull/105
 DOMAIN-SUFFIX,chatgpt.site
 DOMAIN-SUFFIX,chat.com
 DOMAIN-SUFFIX,ai.com


### PR DESCRIPTION
## Summary

- add `chatgpt.site` and all of its subdomains to the AI ruleset

## Why

`chatgpt.site` is the domain used by ChatGPT Sites. The root domain redirects to OpenAI's Sites documentation, and the official documentation shows generated sites on subdomains such as `goblin-tales.openai.chatgpt.site`.

Using `DOMAIN-SUFFIX` covers both the root domain and generated site subdomains.

Reference: https://learn.chatgpt.com/docs/sites

## Validation

- `pnpm lint` (0 errors; existing repository warnings only)
- `pnpm run build`
- confirmed the generated Surge, Mihomo, and sing-box AI outputs include `chatgpt.site`
