### PR TITLE
Update Direct Hosts: `collegeboard.org`

### DIFF
--- a/Source/non_ip/direct.conf
+++ b/Source/non_ip/direct.conf
@@ -210,3 +210,6 @@ DOMAIN-SUFFIX,springernature.com
 
 # ACM (Association for Computing Machinery)
 DOMAIN-SUFFIX,acm.org
+
+# College Board
+DOMAIN-SUFFIX,collegeboard.org


### PR DESCRIPTION
This domain shouldn’t be proxied according to Bluebook instruction “[Configure Your Network](https://bluebook.collegeboard.org/technology/networks/configure)” by College Board.

I've done test for it, once I route the domain to direct access, Bluebook app starts working; I also don't see this domain being blocked or DNS hijacked whatsoever in China.