### PR TITLE
Update AI Hosts: `cursor.sh`

### DIFF
--- a/Source/non_ip/ai.conf
+++ b/Source/non_ip/ai.conf
@@ -122,3 +122,9 @@ DOMAIN,api.jetbrains.ai
 # >> OpenRouter AI - Unified Relay
 # see https://github.com/SukkaW/Surge/pull/86 for reason that only root domain get proxied
 DOMAIN,openrouter.ai
+
+# >> Cursor
+# cursor.com is the marketing site, no geo blocking
+# DOMAIN-SUFFIX,cursor.com
+# Region is determined by the client IP of *.cursor.sh API requests
+DOMAIN-SUFFIX,cursor.sh


### PR DESCRIPTION
## Summary

- Add `DOMAIN-SUFFIX,cursor.sh` to `Source/non_ip/ai.conf`.
- Do not add `cursor.com`: it is the marketing site and has no geo blocking.

This follows up on the hold in https://github.com/SukkaW/Surge/pull/96. That PR used `DOMAIN,cursor.sh` / `DOMAIN,cursor.com`, which does not match API hosts such as `api2.cursor.sh`.

## Why

Cursor determines region from the client IP of `*.cursor.sh` API requests. Official staff have said the same: Cursor checks region by IP on the server side, and a China egress IP blocks OpenAI / Claude models.

`GetMe` on `api2.cursor.sh` returns a country code that follows the egress path. `AvailableModels` is not the geo gate: the protobuf is byte-identical across CN / HK / US.

CDN and download hosts are already covered (`.cursor-cdn.com`, `downloads.cursor.com`).

## Geo evidence

`POST https://api2.cursor.sh/aiserver.v1.DashboardService/GetMe` (authenticated)

| Path | Cloudflare `loc` | GetMe country |
| --- | --- | --- |
| Mainland China (direct) | CN | CN |
| Hong Kong | HK | HK |
| United States | US | US |

`POST https://api2.cursor.sh/aiserver.v1.AiService/AvailableModels` returned the same body on CN / HK / US.

`cursor.com` returned HTTP 200 on all three paths and only set a `logoCountry` cookie (`CN` / `HK` / `US`). No block page.

Unauthenticated `GET https://api2.cursor.sh/` is `200 Welcome to Cursor` from CN as well; GFW is not what this rule is for.

## Validation

- Source change is `Source/non_ip/ai.conf` only.
